### PR TITLE
handling self-closing tags

### DIFF
--- a/dlnap/dlnap.py
+++ b/dlnap/dlnap.py
@@ -112,6 +112,12 @@ def _get_tag_value(x, i = 0):
       i += 1
 
    i += 1 # >
+   
+   # replace self-closing <tag/> by <tag>None</tag> 
+   empty_elmt = '<' + tag + ' />'
+   closed_elmt = '<' + tag + '>None</'+tag+'>'
+   if x.startswith(empty_elmt):
+      x = x.replace(empty_elmt, closed_elmt)
 
    while i < len(x):
       value += x[i]


### PR DESCRIPTION
To avoid structure problems with the xml2dict script when having self-closing tags, replacing <tag /> by <tag>None</tag>